### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/arey0253/7b6f5e83-c220-401e-86fc-9b559bce4155/65a9eaa1-b858-4fba-be57-0cd27f79bfd9/_apis/work/boardbadge/6bc58e67-c2da-4a5d-b030-799037c7eb49)](https://dev.azure.com/arey0253/7b6f5e83-c220-401e-86fc-9b559bce4155/_boards/board/t/65a9eaa1-b858-4fba-be57-0cd27f79bfd9/Microsoft.RequirementCategory)
 # tests
 This is a repo for tests.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/arey0253/7b6f5e83-c220-401e-86fc-9b559bce4155/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.